### PR TITLE
Implementado CafeDispatcher

### DIFF
--- a/cafe.rb
+++ b/cafe.rb
@@ -1,11 +1,4 @@
 class Cafe
-  WHITELIST = %i(fiz tem? tem cabou cabo comofaz :middle_finger: 🖕).freeze
-
-  def handle(action)
-    fail ArgumentError, action unless WHITELIST.include? action.to_sym
-    send(action)
-  end
-
   def fiz
     @cabou_em = nil
     @feito_em = Time.now

--- a/cafe_dispatcher.rb
+++ b/cafe_dispatcher.rb
@@ -1,0 +1,25 @@
+class CafeDispatcher
+  ActionNotFound = Class.new(StandardError)
+
+  def initialize(cafe, command_parser:)
+    @cafe = cafe
+    @command_parser = command_parser
+  end
+
+  def call(command)
+    args = @command_parser.call(command)
+    fail ActionNotFound unless valid_args?(args)
+
+    dispatch_and_return_response(args)
+  end
+
+  private
+
+  def valid_args?(args)
+    !args.nil? && @cafe.method(args[0]).arity == args.length - 1
+  end
+
+  def dispatch_and_return_response(args)
+    @cafe.public_send(*args)
+  end
+end

--- a/cafe_dispatcher_test.rb
+++ b/cafe_dispatcher_test.rb
@@ -1,0 +1,65 @@
+require 'minitest/autorun'
+require 'ostruct'
+require_relative 'cafe_dispatcher'
+
+class CafeDispatcherTest < Minitest::Test
+  class CommandParserFake
+    def initialize(returns:)
+      @returns = returns
+    end
+
+    def call(command)
+      @returns
+    end
+  end
+
+  def test_fails_when_args_returnd_by_command_parser_is_nil
+    cafe = Object.new
+    command_parser = CommandParserFake.new(returns: nil)
+    dispatcher = CafeDispatcher.new(cafe, command_parser: command_parser)
+
+    assert_raises(CafeDispatcher::ActionNotFound) { dispatcher.call('fiz') }
+  end
+
+  def test_fails_when_args_returned_by_command_parser_have_wrong_arity
+    cafe = Object.new
+    cafe.define_singleton_method(:quem_faz) { |one_argument| }
+    command_parser = CommandParserFake.new(returns: [:quem_faz])
+    dispatcher = CafeDispatcher.new(cafe, command_parser: command_parser)
+
+    assert_raises(CafeDispatcher::ActionNotFound) { dispatcher.call('quem_faz') }
+  end
+
+  def test_dispatches_to_cafe_when_command_parser_returns_args_with_no_options
+    cafe = Object.new
+    cafe.define_singleton_method(:quem_faz?) { 'verify_me' }
+    command_parser = CommandParserFake.new(returns: [:quem_faz?])
+    dispatcher = CafeDispatcher.new(cafe, command_parser: command_parser)
+
+    response = dispatcher.call('quem faz?')
+
+    assert_equal 'verify_me', response
+  end
+
+  def test_dispatches_to_cafe_when_command_parser_returns_args_with_options
+    cafe = Object.new
+    cafe.define_singleton_method(:quem_faz) { |args| 'verify_me' }
+    command_parser = CommandParserFake.new(returns: ['quem_faz', 'joao maria'])
+    dispatcher = CafeDispatcher.new(cafe, command_parser: command_parser)
+
+    response = dispatcher.call('quem faz')
+
+    assert_equal 'verify_me', response
+  end
+
+  def test_returns_cafe_response_when_dispatched
+    cafe = Object.new
+    cafe.define_singleton_method(:quem_faz) { |names| 'OK, anotado' }
+    command_parser = CommandParserFake.new(returns: ['quem_faz', 'joao maria'])
+    dispatcher = CafeDispatcher.new(cafe, command_parser: command_parser)
+
+    response = dispatcher.call('quem faz')
+
+    assert_equal 'OK, anotado', response
+  end
+end

--- a/cafe_test.rb
+++ b/cafe_test.rb
@@ -9,21 +9,21 @@ class CafeTest < Minitest::Test
   def test_quando_fiz_tem
     time = Time.now.strftime("%H:%M")
 
-    assert_equal "Opa, café tá pronto!", @cafe.handle(:fiz)
-    assert @cafe.handle(:tem).include? time
-    assert @cafe.handle(:tem?).include? time
+    assert_equal "Opa, café tá pronto!", @cafe.fiz
+    assert @cafe.tem.include? time
+    assert @cafe.tem?.include? time
   end
 
   def test_quando_cabou_nao_tem
     time = Time.now.strftime("%H:%M")
 
-    assert_equal "Ih, cabou café :(", @cafe.handle(:cabou)
-    assert_equal "Ih, cabou café :(", @cafe.handle(:cabo)
-    assert @cafe.handle(:tem).include? time
+    assert_equal "Ih, cabou café :(", @cafe.cabou
+    assert_equal "Ih, cabou café :(", @cafe.cabo
+    assert @cafe.tem.include? time
   end
 
   def test_quando_nao_sabe_nao_sabe
-    assert_equal "Ixi, nem sei. Veja e me diga", @cafe.handle(:tem)
+    assert_equal "Ixi, nem sei. Veja e me diga", @cafe.tem
   end
 
   def test_comofaz
@@ -33,7 +33,7 @@ Pra um café mais fraco estilo 'murica, 1 colher bem cheia pra cada 5 xícaras.
 Se vai botar açucar então foda-se faz aí de qualquer jeito mesmo.
     RECEITA
 
-    assert_equal receita, @cafe.handle(:comofaz)
+    assert_equal receita, @cafe.comofaz
   end
 
   def test_🖕
@@ -45,11 +45,7 @@ Se vai botar açucar então foda-se faz aí de qualquer jeito mesmo.
       "__|__",
       "👉👌"
     ]
-    assert xingamentos.include? @cafe.handle("🖕")
-    assert xingamentos.include? @cafe.handle(":middle_finger:")
-  end
-
-  def test_whitelist
-    assert_raises(ArgumentError) { @cafe.handle('object_id') }
+    assert xingamentos.include? @cafe.public_send("🖕")
+    assert xingamentos.include? @cafe.public_send(":middle_finger:")
   end
 end

--- a/command_parser.rb
+++ b/command_parser.rb
@@ -1,0 +1,49 @@
+require 'forwardable'
+
+class CommandParser
+  def initialize(whitelist:)
+    @whitelist = Whitelist.new(whitelist)
+  end
+
+  def call(command)
+    @whitelist.each do |action_definition|
+      args = decompose_command(*action_definition, command)
+      return args if args
+    end
+
+    nil
+  end
+
+  private
+
+  def decompose_command(action_name, action_regex, command)
+    return unless command =~ action_regex
+
+    arguments = command.gsub(action_regex, '').strip
+    arguments = nil if arguments.empty?
+
+    [action_name, *arguments]
+  end
+
+  class Whitelist
+    extend Forwardable
+
+    delegate each: :@whitelist
+
+    def initialize(whitelist)
+      @whitelist = whitelist.map { |action| parse_action(action) }
+    end
+
+    private
+
+    def parse_action(action_name)
+      [action_name, /\A#{build_action_regex(action_name)}/]
+    end
+
+    def build_action_regex(action_name)
+      Regexp.escape(action_name).to_s.gsub(/[-_\s]/, '[-_\s]')
+    end
+  end
+
+  private_constant :Whitelist
+end

--- a/command_parser_test.rb
+++ b/command_parser_test.rb
@@ -1,0 +1,47 @@
+require 'minitest/autorun'
+require_relative 'command_parser'
+
+class CommandParserTest < Minitest::Test
+  def test_returns_parsed_command_when_main_command_of_raw_command_is_present_in_whitelist
+    parser = CommandParser.new(whitelist: [:fiz])
+
+    assert_equal [:fiz], parser.call('fiz')
+  end
+
+  def test_returns_parsed_command_when_raw_command_matches_whitelist_but_has_spaces
+    parser = CommandParser.new(whitelist: [:fez_cafe])
+
+    assert_equal [:fez_cafe], parser.call('fez cafe')
+  end
+
+  def test_returns_parsed_command_when_raw_command_matches_whitelist_but_has_dashes
+    parser = CommandParser.new(whitelist: [:fez_cafe])
+
+    assert_equal [:fez_cafe], parser.call('fez-cafe')
+  end
+
+  def test_returns_parsed_command_when_main_command_of_raw_command_has_question_mark
+    parser = CommandParser.new(whitelist: [:fez?])
+
+    assert_equal [:fez?], parser.call('fez?')
+  end
+
+  def test_returns_parsed_command_with_arguments_when_raw_command_has_arguments
+    parser = CommandParser.new(whitelist: [:quem_faz])
+
+    assert_equal [:quem_faz, 'joao, maria'], parser.call('quem faz joao, maria')
+  end
+
+  def test_does_not_return_parsed_command_when_main_command_of_raw_command_is_not_at_the_start
+    parser = CommandParser.new(whitelist: [:fiz])
+
+    assert_nil parser.call('fez fiz')
+    assert_nil parser.call('ffiz')
+  end
+
+  def test_does_not_return_parsed_command_when_main_command_of_raw_command_is_not_present_in_whitelist
+    parser = CommandParser.new(whitelist: [:fez])
+
+    assert_nil parser.call('fiz')
+  end
+end

--- a/tem_cafe_test.rb
+++ b/tem_cafe_test.rb
@@ -9,22 +9,55 @@ class TemCafeTest < Minitest::Test
 
   include Rack::Test::Methods
 
+  def setup
+    TemCafe.settings.token = 'my_token'
+  end
+
+  def teardown
+    TemCafe.settings.token = nil
+  end
+
   def app
     TemCafe
   end
 
-  def test_nao_permite_acesso_sem_token
+  def test_nao_permite_acesso_sem_token_configurado
+    TemCafe.settings.token = nil
+
     post '/', channel_id: "channel-id", text: "tem"
     assert last_response.status == 401
   end
 
-  def test_permite_acesso_com_token_correto
-    post '/', channel_id: "channel-id", text: "tem", token: ENV["SLACK_TOKEN"]
+  def test_nao_permite_acesso_com_token_errado
+    TemCafe.settings.token = 'my_token'
+
+    post '/', channel_id: "channel-id", text: "tem", token: "errado"
+    assert last_response.status == 401
+  end
+
+  def test_permite_acesso_com_token_correto_e_retorna_corretamente
+    post '/', channel_id: "channel-id", text: "tem", token: "my_token"
+
     assert last_response.status == 200
+    response = JSON.parse(last_response.body)
+    assert_equal 'in_channel', response['response_type']
+    refute response['text'].nil?
+  end
+
+  def test_integracao
+    post '/', channel_id: "channel-id", text: "fiz", token: "my_token"
+    response = JSON.parse(last_response.body)
+
+    assert_equal 'Opa, café tá pronto!', response['text']
+
+    post '/', channel_id: "channel-id", text: "tem?", token: "my_token"
+    response = JSON.parse(last_response.body)
+
+    assert_match /\ATem :\)/, response['text']
   end
 
   def test_nao_permite_metodos_fora_da_whitelist
-    post '/', channel_id: "channel-id", text: "object_id", token: ENV["SLACK_TOKEN"]
+    post '/', channel_id: "channel-id", text: "object_id", token: "my_token"
     assert last_response.status == 500
   end
 end


### PR DESCRIPTION
- Separa as responsabilidades de dispatcher da classe Cafe
- Permite que seja chamado assim:

/cafe quem faz?

E assim também:

/cafe quem_faz?

Ou até mesmo com argumentos:

/cafe quem faz: joao, maria
